### PR TITLE
Greatly improved speed if image is not a gif

### DIFF
--- a/Model/Resizer.php
+++ b/Model/Resizer.php
@@ -315,6 +315,9 @@ class Resizer
         $filepointer = null;
 
         if (is_string($file)) {
+            if (strpos(strtolower($file), '.gif') === false) {
+                return false;
+            }
             $filepointer = fopen($file, "rb");
         } else {
             $filepointer = $file;


### PR DESCRIPTION
Using this module before with 10 images (Not gif images) took 4 seconds in total.
Using this module with this edit it will be able to do this in 1 second.

Those benchmarks were done on images that have already been cached already.

All the file operations are relatively heavy, instead of starting with those do a very simple check if we are even dealing with a gif.