### PR TITLE
Add support for watermark images

### DIFF
--- a/Model/Resizer.php
+++ b/Model/Resizer.php
@@ -293,6 +293,15 @@ class Resizer
 
         $imageAdapter = $this->imageAdapterFactory->create();
         $imageAdapter->open($this->getAbsolutePathOriginal());
+        if ($this->resizeSettings['watermark'] && file_exists($this->resizeSettings['watermark']['imagePath'])) {
+            $imageAdapter->watermark(
+                $this->resizeSettings['watermark']['imagePath'],
+                $this->resizeSettings['watermark']['x'] ?? null,
+                $this->resizeSettings['watermark']['y'] ?? null,
+                $this->resizeSettings['watermark']['opacity'] ?? null,
+                $this->resizeSettings['watermark']['tile'] ?? null
+            );
+        }
         $imageAdapter->constrainOnly($this->resizeSettings['constrainOnly']);
         $imageAdapter->keepAspectRatio($this->resizeSettings['keepAspectRatio']);
         $imageAdapter->keepTransparency($this->resizeSettings['keepTransparency']);


### PR DESCRIPTION
Fixes #25

Simply passes the resizeSettings for the watermark along to the watermark function of the specified image adapter.
But only if the imagePath can be found.